### PR TITLE
Fix compilation error

### DIFF
--- a/webdriver.opam
+++ b/webdriver.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/art-w/ocaml-webdriver/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
+  "base64"
   "yojson"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
It seems base64 was forgotten as dependency. I've added it and now it compiles correctly.