### PR TITLE
Add chrome headless

### DIFF
--- a/src/webdriver.ml
+++ b/src/webdriver.ml
@@ -163,6 +163,21 @@ module Make (Client : HTTP_CLIENT) = struct
 
     let chrome = capabilities @@ first_match [browser_name "chrome"]
 
+    let chrome_headless =
+        capabilities
+        @@ first_match
+         [ `Assoc [ "browserName", `String "chrome"
+                  ; "goog:chromeOptions",
+                    `Assoc [ "args", `List [ `String "--headless" 
+                                           ; `String "--disable-gpu"
+                                           ; `String "--no-sandbox"
+                                           ; `String "--disable-dev-shm-usage"
+                                           ; `String "--window-size=1920,1080"
+                                           ]
+                           ]
+                  ]
+         ]
+
     let firefox = capabilities @@ first_match [browser_name "firefox"]
 
     let firefox_headless =


### PR DESCRIPTION
Just a firefox_headless I've added a chrome_headless, this time with the preferred arguments for a headless run ([https://itnext.io/how-to-run-a-headless-chrome-browser-in-selenium-webdriver-c5521bc12bf0]). SInce the default chrome window size of 800x600 seems a bit small nowadays, I've changed this to 1920x1080 (although this may be too big).